### PR TITLE
Also accept "red", "green" and "blue" for colour property

### DIFF
--- a/miniply.cpp
+++ b/miniply.cpp
@@ -1317,7 +1317,8 @@ namespace miniply {
 
   bool PLYReader::find_color(uint32_t propIdxs[3]) const
   {
-    return find_properties(propIdxs, 3, "r", "g", "b");
+    return find_properties(propIdxs, 3, "r", "g", "b") ||
+           find_properties(propIdxs, 3, "red", "green", "blue"); 
   }
 
 


### PR DESCRIPTION
As discussed- update `find_color` to also look for red, green and blue if it can't find r, g and b.