### PR TITLE
Add float32 and float64 property types to parser

### DIFF
--- a/miniply.cpp
+++ b/miniply.cpp
@@ -72,6 +72,7 @@ namespace miniply {
     { "uint",   PLYPropertyType::UInt   },
     { "float",  PLYPropertyType::Float  },
     { "float32",PLYPropertyType::Float  },
+    { "float64",PLYPropertyType::Double  },
     { "double", PLYPropertyType::Double },
 
     { "uint8",  PLYPropertyType::UChar  },

--- a/miniply.cpp
+++ b/miniply.cpp
@@ -71,6 +71,7 @@ namespace miniply {
     { "int",    PLYPropertyType::Int    },
     { "uint",   PLYPropertyType::UInt   },
     { "float",  PLYPropertyType::Float  },
+    { "float32",PLYPropertyType::Float  },
     { "double", PLYPropertyType::Double },
 
     { "uint8",  PLYPropertyType::UChar  },


### PR DESCRIPTION
Some PLY files I've encountered have `float32` as the type, so I've added that as a type alias when parsing the file. I've also added the only other missing property, `float64` (listed on the wikipedia page for the PLY file format):

"The type can be specified with one of char uchar short ushort int uint float double, or one of int8 uint8 int16 uint16 int32 uint32 float32 float64."