### PR TITLE
miniply fix not loading correctly big ply files

### DIFF
--- a/miniply.cpp
+++ b/miniply.cpp
@@ -1608,7 +1608,7 @@ namespace miniply {
 
   bool PLYReader::load_fixed_size_element(PLYElement& elem)
   {
-    size_t numBytes = elem.count * elem.rowStride;
+    size_t numBytes = static_cast<size_t>(elem.count) * elem.rowStride;
 
     m_elementData.resize(numBytes);
 
@@ -1679,7 +1679,7 @@ namespace miniply {
 
   bool PLYReader::load_variable_size_element(PLYElement& elem)
   {
-    m_elementData.resize(elem.count * elem.rowStride);
+    m_elementData.resize(static_cast<size_t>(elem.count) * elem.rowStride);
 
     // Preallocate enough space for each row in the property to contain three
     // items. This is based on the assumptions that (a) the most common use for


### PR DESCRIPTION
`elem.count` is a `uint32_t` and when it's multiplied by `elem.rowStride` it will overflow `uint32_t` if count is big enough. The cast makes sure that we work with size_t instead